### PR TITLE
Another MediaEngine sample

### DIFF
--- a/WindowsDesktop.sln
+++ b/WindowsDesktop.sln
@@ -119,6 +119,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinMaxGPUApp", "WindowsDesk
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaEngineApp", "WindowsDesktop\MediaFoundation\MediaEngineApp\MediaEngineApp.csproj", "{72370861-90C4-46C3-8B66-C0D85370659C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaEngineAppVideo", "WindowsDesktop\MediaFoundation\MediaEngineAppVideo\MediaEngineAppVideo.csproj", "{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -455,6 +457,14 @@ Global
 		{72370861-90C4-46C3-8B66-C0D85370659C}.Win8Debug|Any CPU.Build.0 = Debug|Any CPU
 		{72370861-90C4-46C3-8B66-C0D85370659C}.Win8Release|Any CPU.ActiveCfg = Release|Any CPU
 		{72370861-90C4-46C3-8B66-C0D85370659C}.Win8Release|Any CPU.Build.0 = Release|Any CPU
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}.Win8Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}.Win8Debug|Any CPU.Build.0 = Debug|Any CPU
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}.Win8Release|Any CPU.ActiveCfg = Release|Any CPU
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}.Win8Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -501,5 +511,6 @@ Global
 		{A4BEB287-F2CF-471F-B432-A348E3680A1D} = {98758F79-6B27-4A77-A5DD-74AFDB2DA482}
 		{48F1120F-3F33-4542-A696-D99BF675258E} = {9F670CC4-1680-4967-99FB-B397024DD10A}
 		{72370861-90C4-46C3-8B66-C0D85370659C} = {BD136A46-83B6-4497-9566-1CE674F76ACB}
+		{232B973F-403D-41F0-BD99-8FE0ED4CBE1D} = {BD136A46-83B6-4497-9566-1CE674F76ACB}
 	EndGlobalSection
 EndGlobal

--- a/WindowsDesktop/MediaFoundation/MediaEngineAppVideo/MediaEngineAppVideo.csproj
+++ b/WindowsDesktop/MediaFoundation/MediaEngineAppVideo/MediaEngineAppVideo.csproj
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{232B973F-403D-41F0-BD99-8FE0ED4CBE1D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MediaEngineAppVideo</RootNamespace>
+    <AssemblyName>MediaEngineAppVideo</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>b47b1b3c</NuGetPackageImportStamp>
+    <SharpDXDirectXVersion>DirectX11_2</SharpDXDirectXVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="SharpDX">
+      <HintPath>$(SharpDXPackageBinDir)\SharpDX.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.Direct3D11">
+      <HintPath>$(SharpDXPackageBinDir)\SharpDX.Direct3D11.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.DXGI, Version=2.6.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SharpDXPackageBinDir)\SharpDX.DXGI.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.MediaFoundation">
+      <HintPath>$(SharpDXPackageBinDir)\SharpDX.MediaFoundation.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\packages\SharpDX.2.6.0\build\SharpDX.targets" Condition="Exists('..\..\..\packages\SharpDX.2.6.0\build\SharpDX.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\SharpDX.2.6.0\build\SharpDX.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\SharpDX.2.6.0\build\SharpDX.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/WindowsDesktop/MediaFoundation/MediaEngineAppVideo/Program.cs
+++ b/WindowsDesktop/MediaFoundation/MediaEngineAppVideo/Program.cs
@@ -1,0 +1,238 @@
+﻿// Copyright (c) 2010-2013 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Threading;
+using System.Windows.Forms;
+
+using SharpDX.Direct3D;
+using SharpDX.Direct3D11;
+using SharpDX.MediaFoundation;
+
+using DXDevice = SharpDX.Direct3D11.Device;
+using SharpDX.DXGI;
+using SharpDX.Windows;
+
+namespace MediaEngineApp
+{
+    /// <summary>
+    /// Demonstrates simple usage of MediaEngine on Windows by playing a video and audio selected by a file dialog.
+    /// Note that this sample is not "Dispose" safe and is not releasing any COM resources.
+    /// Also please note that this sample might not work on NVidia Cards (due to video engine broken on many drivers),
+    /// This has been tested and working on Intel and ATI.
+    /// </summary>
+    class Program
+    {
+        /// <summary>
+        /// The event raised when MediaEngine is ready to play the music.
+        /// </summary>
+        private static readonly ManualResetEvent eventReadyToPlay = new ManualResetEvent(false);
+
+        /// <summary>
+        /// Set when the music is stopped.
+        /// </summary>
+        private static bool isMusicStopped;
+
+        /// <summary>
+        /// The instance of MediaEngineEx
+        /// </summary>
+        private static MediaEngineEx mediaEngineEx;
+
+        /// <summary>
+        /// Our dx11 device
+        /// </summary>
+        private static DXDevice device;
+
+        /// <summary>
+        /// Our SwapChain
+        /// </summary>
+        private static SwapChain swapChain;
+
+        /// <summary>
+        /// DXGI Manager
+        /// </summary>
+        private static DXGIDeviceManager dxgiManager;
+
+
+
+        /// <summary>
+        /// Defines the entry point of the application.
+        /// </summary>
+        /// <param name="args">The args.</param>
+        [STAThread]
+        static void Main(string[] args)
+        {
+            // Select a File to play
+            var openFileDialog = new OpenFileDialog { Title = "Select a file", Filter = "Media Files(*.WMV;*.MP4;*.AVI)|*.WMV;*.MP4;*.AVI" };
+            var result = openFileDialog.ShowDialog();
+            if (result == DialogResult.Cancel)
+            {
+                return;
+            }
+
+            // Initialize MediaFoundation
+            MediaManager.Startup();
+
+            var renderForm = new SharpDX.Windows.RenderForm();
+
+            device = CreateDeviceForVideo(out dxgiManager);
+
+            // Creates the MediaEngineClassFactory
+            var mediaEngineFactory = new MediaEngineClassFactory();
+            
+            //Assign our dxgi manager, and set format to bgra
+            MediaEngineAttributes attr = new MediaEngineAttributes();
+            attr.VideoOutputFormat = (int)SharpDX.DXGI.Format.B8G8R8A8_UNorm;
+            attr.DxgiManager = dxgiManager;
+
+            // Creates MediaEngine for AudioOnly 
+            var mediaEngine = new MediaEngine(mediaEngineFactory, attr, MediaEngineCreateFlags.None);
+
+            // Register our PlayBackEvent
+            mediaEngine.PlaybackEvent += OnPlaybackCallback;
+
+            // Query for MediaEngineEx interface
+            mediaEngineEx = mediaEngine.QueryInterface<MediaEngineEx>();
+
+            // Opens the file
+            var fileStream = openFileDialog.OpenFile();
+            
+            // Create a ByteStream object from it
+            var stream = new ByteStream(fileStream);
+
+            // Creates an URL to the file
+            var url = new Uri(openFileDialog.FileName, UriKind.RelativeOrAbsolute);
+
+            // Set the source stream
+            mediaEngineEx.SetSourceFromByteStream(stream, url.AbsoluteUri);
+
+            // Wait for MediaEngine to be ready
+            if (!eventReadyToPlay.WaitOne(1000))
+            {
+                Console.WriteLine("Unexpected error: Unable to play this file");
+            }
+
+            //Create our swapchain
+            swapChain = CreateSwapChain(device, renderForm.Handle);
+
+            //Get DXGI surface to be used by our media engine
+            var texture = Texture2D.FromSwapChain<Texture2D>(swapChain, 0);
+            var surface = texture.QueryInterface<SharpDX.DXGI.Surface>();
+
+            //Get our video size
+            int w, h;
+            mediaEngine.GetNativeVideoSize(out w, out h);
+
+            // Play the music
+            mediaEngineEx.Play();
+
+            long ts;
+
+            RenderLoop.Run(renderForm, () =>
+            {
+                //Transfer frame if a new one is available
+                if (mediaEngine.OnVideoStreamTick(out ts))
+                {
+                    mediaEngine.TransferVideoFrame(surface, null, new SharpDX.Rectangle(0, 0, w, h), null);
+                }
+
+                swapChain.Present(1, SharpDX.DXGI.PresentFlags.None);
+            });
+
+            mediaEngine.Shutdown();
+            swapChain.Dispose();
+            device.Dispose();
+        }
+
+        /// <summary>
+        /// Called when [playback callback].
+        /// </summary>
+        /// <param name="playEvent">The play event.</param>
+        /// <param name="param1">The param1.</param>
+        /// <param name="param2">The param2.</param>
+        private static void OnPlaybackCallback(MediaEngineEvent playEvent, long param1, int param2)
+        {
+            switch (playEvent)
+            {
+                case MediaEngineEvent.CanPlay:
+                    eventReadyToPlay.Set();
+                    break;
+                case MediaEngineEvent.TimeUpdate:
+                    break;
+                case MediaEngineEvent.Error:
+                case MediaEngineEvent.Abort:
+                case MediaEngineEvent.Ended:
+                    isMusicStopped = true;
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Creates device with necessary flags for video processing
+        /// </summary>
+        /// <param name="manager">DXGI Manager, used to create media engine</param>
+        /// <returns>Device with video support</returns>
+        private static DXDevice CreateDeviceForVideo(out DXGIDeviceManager manager)
+        {
+            //Device need bgra and video support
+            var device = new DXDevice(SharpDX.Direct3D.DriverType.Hardware, DeviceCreationFlags.BgraSupport | DeviceCreationFlags.VideoSupport);
+
+            //Add multi thread protection on device
+            DeviceMultithread mt = device.QueryInterface<DeviceMultithread>();
+            mt.SetMultithreadProtected(true);
+
+            //Reset device
+            manager = new DXGIDeviceManager();
+            manager.ResetDevice(device);
+
+            return device;
+        }
+
+        /// <summary>
+        /// Creates swap chain ready to use for video output
+        /// </summary>
+        /// <param name="dxdevice">DirectX11 device</param>
+        /// <param name="handle">RenderForm Handle</param>
+        /// <returns>SwapChain</returns>
+        private static SwapChain CreateSwapChain(DXDevice dxdevice, IntPtr handle)
+        {
+            //Walk up device to retrieve Factory, necessary to create SwapChain
+            var dxgidevice = dxdevice.QueryInterface<SharpDX.DXGI.Device>();           
+            var adapter =  dxgidevice.Adapter.QueryInterface<Adapter>();
+            var factory = adapter.GetParent<Factory1>();
+
+            /*To be allowed to be used as video, texture must be of the same format (eg: bgra), and needs to be bindable are render target.
+             * you do not need to create render target view, only the flag*/
+            SwapChainDescription sd = new SwapChainDescription()
+            {
+                BufferCount = 1,
+                ModeDescription = new ModeDescription(0, 0, new Rational(60, 1), Format.B8G8R8A8_UNorm),
+                IsWindowed = true,
+                OutputHandle = handle,
+                SampleDescription = new SampleDescription(1,0),
+                SwapEffect = SwapEffect.Discard,
+                Usage = Usage.RenderTargetOutput,
+                Flags = SwapChainFlags.None
+            };
+
+           return new SwapChain(factory, dxdevice, sd);
+        }
+    }
+}

--- a/WindowsDesktop/MediaFoundation/MediaEngineAppVideo/Properties/AssemblyInfo.cs
+++ b/WindowsDesktop/MediaFoundation/MediaEngineAppVideo/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MediaEngineApp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MediaEngineApp")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fc882771-0461-486c-922d-6823c28a5913")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WindowsDesktop/MediaFoundation/MediaEngineAppVideo/packages.config
+++ b/WindowsDesktop/MediaFoundation/MediaEngineAppVideo/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SharpDX" version="2.6.0" targetFramework="net40" />
+  <package id="SharpDX.Direct3D11" version="2.6.0" targetFramework="net40" />
+  <package id="SharpDX.DXGI" version="2.6.0" targetFramework="net40" />
+  <package id="SharpDX.MediaFoundation" version="2.6.0" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
Hello,

Just added a second very simple example (based on audio media engine), which also plays video.

Please note that media engine on NVidia is really buggy (if it even works). So playback on those card will just likely crash.

https://devtalk.nvidia.com/default/topic/524892/directx-and-direct-compute/why-imfmediaengine-transfervideoframe-return-e_fail-and-throw-a-exception-on-gts-250-on-64-bit-wind/

Thanks
Julien
