### PR TITLE
NullRefException at MiniCube sample

### DIFF
--- a/WindowsPhone8/MiniCube/SharpDXBase.cs
+++ b/WindowsPhone8/MiniCube/SharpDXBase.cs
@@ -44,10 +44,11 @@ namespace MiniTriApp
                 CreateDeviceResources();
                 isNewDevice = true;
             }
-            _deviceContext.ClearState();
-
+            
             _deviceContext = context;
             _renderTargetview = renderTargetView;
+
+            _deviceContext.ClearState();
 
             CreateWindowSizeDependentResources(isNewDevice);
         }


### PR DESCRIPTION
First time Update() is called _deviceContext is null.
