### PR TITLE
Fix MinMaxGPU sample build error in Release configuration

### DIFF
--- a/Desktop/DirectCompute/MinMaxGPUApp/MinMaxGPUApp.csproj
+++ b/Desktop/DirectCompute/MinMaxGPUApp/MinMaxGPUApp.csproj
@@ -14,12 +14,12 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
Release configuration was missing the compiler flag to allow unsafe code blocks.