### PR TITLE
Crash: Properly dispose ResourceFontLoader

### DIFF
--- a/Desktop/DirectWrite/CustomFont/CustomFont.Designer.cs
+++ b/Desktop/DirectWrite/CustomFont/CustomFont.Designer.cs
@@ -7,19 +7,6 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>

--- a/Desktop/DirectWrite/CustomFont/CustomFont.cs
+++ b/Desktop/DirectWrite/CustomFont/CustomFont.cs
@@ -224,9 +224,12 @@ namespace CustomFont
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                if (components != null)
+                {
+                    components.Dispose();
+                }
 
                 CurrentResourceFontLoader.Dispose();
             }

--- a/Desktop/DirectWrite/CustomFont/CustomFont.cs
+++ b/Desktop/DirectWrite/CustomFont/CustomFont.cs
@@ -218,5 +218,19 @@ namespace CustomFont
 
         }
 
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+
+                CurrentResourceFontLoader.Dispose();
+            }
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Desktop/DirectWrite/CustomFont/ResourceFontLoader.cs
+++ b/Desktop/DirectWrite/CustomFont/ResourceFontLoader.cs
@@ -110,5 +110,17 @@ namespace CustomFont
             var index = Utilities.Read<int>(fontFileReferenceKey.Pointer);
             return _fontStreams[index];
         }
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            _factory.UnregisterFontFileLoader(this);
+            _factory.UnregisterFontCollectionLoader(this);
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Desktop/DirectWrite/CustomFont/ResourceFontLoader.cs
+++ b/Desktop/DirectWrite/CustomFont/ResourceFontLoader.cs
@@ -117,8 +117,11 @@ namespace CustomFont
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            _factory.UnregisterFontFileLoader(this);
-            _factory.UnregisterFontCollectionLoader(this);
+            if (disposing)
+            {
+                _factory.UnregisterFontFileLoader(this);
+                _factory.UnregisterFontCollectionLoader(this);
+            }
 
             base.Dispose(disposing);
         }


### PR DESCRIPTION
In this code copied to my project, not unregistering causes a crash:

````
Unhandled exception at 0x00007FFB82883C58 (KernelBase.dll) in Paracosm.Client.exe: 0xC0020001: The string binding is invalid (parameters: 0xFFFFFFFF8007042B).
````