### PR TITLE
Track app

### DIFF
--- a/Desktop/RawInput/RawInputTrackApp/Program.cs
+++ b/Desktop/RawInput/RawInputTrackApp/Program.cs
@@ -67,7 +67,7 @@ namespace MouseTrackApp
             var args = (MouseInputEventArgs)rawArgs;
             var devName = GetDeviceName(args.Device);
             textBox.AppendText(
-                $"Device: {devName} {sep} Coords: {args.X},{args.Y} {sep} Buttons: {args.ButtonFlags} {sep} State: {args.Mode} {sep} Wheel: {args.WheelDelta}\r\n");
+                $"Mouse: {devName} {sep} Coords: {args.X},{args.Y} {sep} Buttons: {args.ButtonFlags} {sep} State: {args.Mode} {sep} Wheel: {args.WheelDelta}\r\n");
         }
 
         static string GetDeviceName(IntPtr devPtr)
@@ -94,8 +94,10 @@ namespace MouseTrackApp
         /// <param name="rawArgs">The <see cref="SharpDX.RawInput.RawInputEventArgs"/> instance containing the event data.</param>
         static void UpdateKeyboardText(RawInputEventArgs rawArgs)
         {
+            const string sep = "        ";
             var args = (KeyboardInputEventArgs)rawArgs;
-            textBox.AppendText(string.Format("Key: {0} State: {1} ScanCodeFlags: {2}\r\n", args.Key, args.State, args.ScanCodeFlags));
+            var devName = GetDeviceName(args.Device);
+            textBox.AppendText($"Keyboard: {devName} {sep} Key: {args.Key} ({(int)args.Key}) {sep} State: {args.State} {sep} ScanCodeFlags: {args.ScanCodeFlags}\r\n");
         }
 
         /// <summary>

--- a/Desktop/RawInput/RawInputTrackApp/Program.cs
+++ b/Desktop/RawInput/RawInputTrackApp/Program.cs
@@ -33,7 +33,7 @@ namespace MouseTrackApp
     static class Program
     {
         private static TextBox textBox;
-        private static ConcurrentDictionary<IntPtr, string> _deviceNameCache = new ConcurrentDictionary<IntPtr, string>();
+        private static readonly ConcurrentDictionary<IntPtr, string> DeviceNameCache = new ConcurrentDictionary<IntPtr, string>();
 
         /// <summary>
         /// The main entry point for the application.
@@ -72,9 +72,9 @@ namespace MouseTrackApp
 
         static string GetDeviceName(IntPtr devPtr)
         {
-            if (_deviceNameCache.ContainsKey(devPtr))
+            if (DeviceNameCache.ContainsKey(devPtr))
             {
-                return _deviceNameCache[devPtr];
+                return DeviceNameCache[devPtr];
             }
             var devices = Device.GetDevices();
             var deviceName = devPtr.ToString();
@@ -84,7 +84,7 @@ namespace MouseTrackApp
                 deviceName = dev.DeviceName.Split('#')[1];
                 break;
             }
-            _deviceNameCache.TryAdd(devPtr, deviceName);
+            DeviceNameCache.TryAdd(devPtr, deviceName);
             return deviceName;
         }
 


### PR DESCRIPTION
**What?**  
Modified the RawInputTrackApp to display the VID/PID of each device it sees data from.  
Uses `Devices.GetDevices()` and caches the result, so each device is only looked up once.  
Falls back to using a string of the pointer address.  
Also added key codes to keyboard readout.  

**Why?**  
I searched for "RawInput Monitor" and other associated terms. Turned up nothing of use.  
I am working with driver level stuff (Interception) and need to see what the OS is seeing. This is about the only tool I can find which tells me.